### PR TITLE
fix the opm-cmake duncontrol support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+all:
+	@echo "No-op"

--- a/configure
+++ b/configure
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# for the opm-cmake module, the configuration is a no-op since it does
+# not provide any C/C++ source files
+exit 0

--- a/dune.module
+++ b/dune.module
@@ -1,0 +1,4 @@
+Module: opm-cmake
+Description: Open Porous Media Initiative build system
+Version: 2015.10
+Maintainer: opm@opm-project.org


### PR DESCRIPTION
this is required to continue supporting the build path via 'dunecontrol'.
(which is the easiest way to build the whole thing, at least until the 
"meta build" cmake scripts become available.)

since the opm-cmake does not contain any source files, placeholder
versions of the configure bash script and Makefile are
sufficient. These files are required because dunecontrol calls
'./configure' and 'make' unconditionally. (Also, the downstream
modules need to depend on opm-cmake to find the build macros...)

I also fixed the other modules which I care for in separate PRs...