### PR TITLE
Fix prerequisites.

### DIFF
--- a/cmake/Modules/opm-polymer-prereqs.cmake
+++ b/cmake/Modules/opm-polymer-prereqs.cmake
@@ -17,5 +17,8 @@ set (opm-polymer_DEPS
 	# Ensembles-based Reservoir Tools
 	"ERT"
 	# OPM dependency
-	"opm-core"
+	"opm-autodiff REQUIRED"
+	"opm-core REQUIRED"
+	# Eigen
+	"Eigen3 3.1 REQUIRED"
 	)


### PR DESCRIPTION
Change made after initial branch of opm-cmake was lost.