### PR TITLE
added: macro to add a single test

### DIFF
--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -256,7 +256,7 @@ endif (BUILD_TESTING)
 # use this target to run all tests
 add_custom_target (check
 	COMMAND ${CMAKE_CTEST_COMMAND}
-	DEPENDS tests
+	DEPENDS test-suite
 	COMMENT "Checking if library is functional"
 	VERBATIM
 	)


### PR DESCRIPTION
- the tests are excluded from the 'all' build target
- the name is appended to a list called test_apps

this is intended to be used for generating an autotools style 'make
check' target, see https://github.com/OPM/opm-parser/pull/469 for an example

this is a simpler version than the current opm_add_satellite for tests without data dependencies.