### PR TITLE
[cmake] Add CMake module for finding PT-Scotch in dune-cornerpoint

### DIFF
--- a/cmake/Modules/FindPTScotch.cmake
+++ b/cmake/Modules/FindPTScotch.cmake
@@ -1,0 +1,83 @@
+# Module that checks whether PT-Scotch is available.
+#
+# Accepts the following variables:
+#
+# PTSCOTCH_ROOT:   Prefix where PT-Scotch is installed.
+# PTSCOTCH_SUFFIX: Scotch might be compiled using different
+#                  integer sizes (int32, int32, long). When
+#                  this is is set the headers and libaries
+#                  are search under the suffix
+#                  include/scotch-${PTSCOTCH_SUFFIX, and
+#                  lib/scotch-${PTSCOTCH_SUFFIX}, respectively.
+# Sets the following variables:
+# PTSCOTCH_INCLUDE_DIRS: All include directories needed to compile PT-Scotch programs.
+# PTSCOTCH_LIBRARIES:    Alle libraries needed to link PT-Scotch programs.
+# PTSCOTCH_FOUND:        True if PT-Scotch was found.
+#
+# Provides the following macros:
+#
+# find_package(PTScotch)
+
+find_package(MPI)
+macro(_search_pt_lib libvar libname doc)
+  find_library(${libvar} ${libname}
+    PATHS${PTSCOTCH_ROOT} PATH_SUFFIXES ${PATH_SUFFIXES}
+    NO_DEFAULT_PATH
+    DOC "${doc}")
+  find_library(${libvar} ${libname})
+endmacro(_search_pt_lib)
+
+if(PTSCOTCH_SUFFIX)
+  set(PATH_SUFFIXES "scotch-${PTSCOTCH_SUFFIX}")
+else(PTSCOTCH_SUFFIX)
+  set(PATH_SUFFIXES "scotch")
+endif(PTSCOTCH_SUFFIX)
+
+include(CMakePushCheckState)
+cmake_push_check_state() # Save variables
+set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${MPI_DUNE_INCLUDE_PATH})
+set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${MPI_DUNE_COMPILE_FLAGS}")
+
+find_path(PTSCOTCH_INCLUDE_DIR ptscotch.h
+  PATHS ${PTSCOTCH_ROOT}
+  PATH_SUFFIXES ${PATH_SUFFIXES}
+  NO_DEFAULT_PATH
+  DOC "Include directory of PT-Scotch")
+find_path(PTSCOTCH_INCLUDE_DIR ptscotch.h
+  PATH_SUFFIXES ${PATH_SUFFIXES})
+
+_search_pt_lib(PTSCOTCH_LIBRARY ptscotch "The main PT-Scotch library.")
+_search_pt_lib(PTSCOTCHERR_LIBRARY ptscotcherr "The PT-Scotch error library.")
+
+# behave like a CMake module is supposed to behave
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  "PTScotch"
+  DEFAULT_MSG
+  PTSCOTCH_INCLUDE_DIR
+  PTSCOTCH_LIBRARY
+  PTSCOTCHERR_LIBRARY
+)
+#restore old values
+cmake_pop_check_state()
+
+if(PTSCOTCH_FOUND)
+  set(PTSCOTCH_INCLUDE_DIRS ${PTSCOTCH_INCLUDE_DIR})
+  set(PTSCOTCH_LIBRARIES ${PTSCOTCH_LIBRARY} ${PTSCOTCHERR_LIBRARY} ${MPI_DUNE_LIBRARIES}
+    CACHE FILEPATH "All libraries needed to link programs using PT-Scotch")
+  set(PTSCOCH_LINK_FLAGS "${DUNE_MPI_LINK_FLAGS}"
+    CACHE STRING "PT-Scotch link flags")
+  set(HAVE_PTSCOTCH 1)
+  # log result
+  file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
+    "Determing location of PT-Scotch succeded:\n"
+    "Include directory: ${PTSCOTCH_INCLUDE_DIRS}\n"
+    "Library directory: ${PTSCOTCH_LIBRARIES}\n\n")
+
+  foreach(dir ${PTSCOCTH_INCLUDE_DIRS})
+    set_property(GLOBAL APPEND PROPERTY ALL_PKG_FLAGS "-I${dir}")
+  endforeach()
+  set_property(GLOBAL APPEND PROPERTY ALL_PKG_LIBS "${PTSCOTCH_LIBRARIES}")
+endif(PTSCOTCH_FOUND)
+
+mark_as_advanced(PTSCOTCH_INCLUDE_DIRS PTSCOTCH_LIBRARIES HAVE_PTSCOTCH)

--- a/cmake/Modules/FindZOLTAN.cmake
+++ b/cmake/Modules/FindZOLTAN.cmake
@@ -16,6 +16,10 @@ if(ZOLTAN_ROOT)
   set(ZOLTAN_NO_DEFAULT_PATH "NO_DEFAULT_PATH")
 endif()
 
+# Make sure we have checked for the underlying partitioners.
+find_package(PTScotch)
+#find_package(ParMETIS)
+
 # search for files which implements this module
 find_path (ZOLTAN_INCLUDE_DIRS
   NAMES "zoltan.h"
@@ -38,6 +42,9 @@ set (ZOLTAN_FOUND FALSE)
 if (ZOLTAN_INCLUDE_DIRS OR ZOLTAN_LIBRARIES)
   set(ZOLTAN_FOUND TRUE)
   set(HAVE_ZOLTAN 1)
+  set(ZOLTAN_LIBRARIES ${ZOLTAN_LIBRARIES} ${PARMETIS_LIBRARIES} ${PTSCOTCH_LIBRARIES})
+  set(ZOLTAN_INCLUDE_DIRS ${ZOLTAN_INCLUDE_DIRS} ${PARMETIS_INCLUDE_DIRS}
+      ${PTSCOTCH_INCLUDE_DIRS})
 endif()
 
 set (ZOLTAN_CONFIG_VAR HAVE_ZOLTAN)

--- a/cmake/Modules/dune-cornerpoint-prereqs.cmake
+++ b/cmake/Modules/dune-cornerpoint-prereqs.cmake
@@ -9,6 +9,7 @@ set (dune-cornerpoint_CONFIG_VAR
 	DUNE_COMMON_VERSION_MAJOR
 	DUNE_COMMON_VERSION_MINOR
 	DUNE_COMMON_VERSION_REVISION
+	HAVE_ZOLTAN
 	)
 
 # dependencies
@@ -26,4 +27,5 @@ set (dune-cornerpoint_DEPS
 	dune-geometry REQUIRED"
 	# OPM dependency
 	"opm-core REQUIRED"
+	"ZOLTAN"
 	)


### PR DESCRIPTION
There already is a module for finding Zoltan, which supports both ParMETIS and PT-Scotch underneath. While the former is only free for academic use the latter is true open source. Therefore
with this commit we add a module for finding PT-Scotch and add the necessary libraries and include paths for ZOLTAN.

This a port of the original PR OPM/opm-core#787