### PR TITLE
fix clock_gettime() on older systems

### DIFF
--- a/cmake/Modules/Findlibrt.cmake
+++ b/cmake/Modules/Findlibrt.cmake
@@ -1,0 +1,51 @@
+# Module that makes the clock_gettime() function available
+#
+# Sets the following variables:
+# HAVE_LIBRT
+# LIBRT_LIBRARIES
+#
+# perform tests
+include(CheckCSourceCompiles)
+
+# first check if we need to add anything at all to be able to use
+# clock_gettime()
+CHECK_CXX_SOURCE_COMPILES("
+#include <time.h>
+
+int main()
+{
+    timespec time1;
+    clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &time1);
+};
+" HAVE_LIBRT)
+cmake_pop_check_state()
+
+if (HAVE_LIBRT)
+  # if this worked, we're already happy
+  set(LIBRT_LIBRARIES "")
+else()
+  # if not, let's try the same program with linking to librt (required
+  # on some systems)
+  cmake_push_check_state()
+  list(APPEND CMAKE_REQUIRED_LIBRARIES "rt")
+  CHECK_CXX_SOURCE_COMPILES("
+#include <time.h>
+
+int main()
+{
+    timespec time1;
+    clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &time1);
+};
+" HAVE_LIBRT2)
+  cmake_pop_check_state()
+  set(HAVE_LIBRT "${HAVE_LIBRT2}")
+  if (HAVE_LIBRT)
+    set(LIBRT_LIBRARIES "rt")
+  endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibRT
+  DEFAULT_MSG
+  HAVE_LIBRT
+  )

--- a/cmake/Modules/ewoms-prereqs.cmake
+++ b/cmake/Modules/ewoms-prereqs.cmake
@@ -25,6 +25,8 @@ set (ewoms_DEPS
 	"opm-material REQUIRED"
 	"dune-alugrid"
 	"dune-cornerpoint"
+	# librt (on some systems necessary for clock_gettime()) 
+	"librt REQUIRED"
 	# valgrind client requests
 	"Valgrind"
 	# quadruple precision floating point calculations


### PR DESCRIPTION
it seems like old systems need to link to librt for this
function. (for newer ones it is already included in libc.)