### PR TITLE
make configure work for ZOLTAN when used with dunecontrol.

### DIFF
--- a/cmake/Modules/FindZOLTAN.cmake
+++ b/cmake/Modules/FindZOLTAN.cmake
@@ -24,7 +24,7 @@ find_package(PTScotch)
 find_path (ZOLTAN_INCLUDE_DIRS
   NAMES "zoltan.h"
   PATHS ${ZOLTAN_SEARCH_PATH}
-  PATH_SUFFIXES "include" 
+  PATH_SUFFIXES "include"
   ${ZOLTAN_NO_DEFAULT_PATH})
 
 # only search in architecture-relevant directory
@@ -48,7 +48,7 @@ if (ZOLTAN_INCLUDE_DIRS OR ZOLTAN_LIBRARIES)
 endif()
 
 set (ZOLTAN_CONFIG_VAR HAVE_ZOLTAN)
-  
+
 # print a message to indicate status of this package
 include (FindPackageHandleStandardArgs)
 find_package_handle_standard_args(ZOLTAN

--- a/cmake/Scripts/configure
+++ b/cmake/Scripts/configure
@@ -48,6 +48,7 @@ Optional Packages:
   --with-superlu=PATH     user defined path to SuperLU library
   --with-umfpack=PATH     use UMFPACK/SuiteSparse from a specified location
   --with-ert=PATH         Use ERT libraries
+  --with-zoltan=PATH      Use ZOLTAN libraries
   --with-tinyxml=PATH     use TinyXML library from a specified location
                           (Note: if not found, then a bundled library will
                            be used)
@@ -265,6 +266,7 @@ for OPT in "$@"; do
             opm-*       |\
             dune        |\
             dune-*      |\
+            zoltan      |\
             zlib)
               rootvar="$(uppercase ${pkgname})_ROOT"
               rootvar="${rootvar/-/_}"


### PR DESCRIPTION
This PR fixes an issue when OPM is configured with dunecontrol.