### PR TITLE
some doxygen cleanups

### DIFF
--- a/cmake/Modules/OpmDoc.cmake
+++ b/cmake/Modules/OpmDoc.cmake
@@ -25,6 +25,16 @@ macro (opm_doc opm doxy_dir)
   file (WRITE ${PROJECT_BINARY_DIR}/${doxy_dir}/Doxyfile.in ${_doxy_templ} ${_doxy_local})
   # set this generically named variable so even the custom file can be shared
   set (src_DIR "${${opm}_DIR}")
+
+  # copy the doxygen layout XML file to the build directorie's doxygen
+  # directory. if the source module ships with such a file it takes
+  # precedence over the one shipped with the build system.
+  if (EXISTS ${PROJECT_SOURCE_DIR}/${doxy_dir}/DoxygenLayout.xml)
+    file(COPY ${PROJECT_SOURCE_DIR}/${doxy_dir}/DoxygenLayout.xml DESTINATION ${PROJECT_BINARY_DIR}/${doxy_dir})
+  else()
+    file(COPY ${OPM_MACROS_ROOT}/cmake/Templates/DoxygenLayout.xml DESTINATION ${PROJECT_BINARY_DIR}/${doxy_dir})
+  endif()
+
   # replace variables in this combined file
   configure_file (
 	${PROJECT_BINARY_DIR}/${doxy_dir}/Doxyfile.in

--- a/cmake/Templates/Doxyfile
+++ b/cmake/Templates/Doxyfile
@@ -277,22 +277,6 @@ INLINE_GROUPED_CLASSES = NO
 
 TYPEDEF_HIDES_STRUCT   = NO
 
-# The SYMBOL_CACHE_SIZE determines the size of the internal cache use to
-# determine which symbols to keep in memory and which to flush to disk.
-# When the cache is full, less often used symbols will be written to disk.
-# For small to medium size projects (<1000 input files) the default value is
-# probably good enough. For larger projects a too small cache size can cause
-# doxygen to be busy swapping symbols to and from disk most of the time
-# causing a significant performance penalty.
-# If the system has enough physical memory increasing the cache will improve the
-# performance by keeping more symbols in memory. Note that the value works on
-# a logarithmic scale so increasing the size by one will roughly double the
-# memory usage. The cache size is given by this formula:
-# 2^(16+SYMBOL_CACHE_SIZE). The valid range is 0..9, the default is 0,
-# corresponding to a cache size of 2^16 = 65536 symbols
-
-SYMBOL_CACHE_SIZE      = 0
-
 #---------------------------------------------------------------------------
 # Build related configuration options
 #---------------------------------------------------------------------------
@@ -495,12 +479,6 @@ MAX_INITIALIZER_LINES  = 30
 # list will mention the files that were used to generate the documentation.
 
 SHOW_USED_FILES        = YES
-
-# If the sources in your project are distributed over multiple directories
-# then setting the SHOW_DIRECTORIES tag to YES will show the directory hierarchy
-# in the documentation. The default is NO.
-
-SHOW_DIRECTORIES       = NO
 
 # Set the SHOW_FILES tag to NO to disable the generation of the Files page.
 # This will remove the Files entry from the Quick Index and from the
@@ -840,12 +818,6 @@ HTML_COLORSTYLE_GAMMA  = 80
 
 HTML_TIMESTAMP         = YES
 
-# If the HTML_ALIGN_MEMBERS tag is set to YES, the members of classes,
-# files or namespaces will be aligned in HTML using tables. If set to
-# NO a bullet list will be used.
-
-HTML_ALIGN_MEMBERS     = YES
-
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the
 # page has loaded. For this to work a browser that supports
@@ -1027,11 +999,6 @@ ENUM_VALUES_PER_LINE   = 4
 # Windows users are probably better off using the HTML help feature.
 
 GENERATE_TREEVIEW      = YES
-
-# By enabling USE_INLINE_TREES, doxygen will generate the Groups, Directories,
-# and Class Hierarchy pages using a tree view instead of an ordered list.
-
-USE_INLINE_TREES       = NO
 
 # If the treeview is enabled (see GENERATE_TREEVIEW) then this tag can be
 # used to set the initial width (in pixels) of the frame in which the tree
@@ -1278,18 +1245,6 @@ GENERATE_XML           = NO
 # put in front of it. If left blank `xml' will be used as the default path.
 
 XML_OUTPUT             = xml
-
-# The XML_SCHEMA tag can be used to specify an XML schema,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_SCHEMA             =
-
-# The XML_DTD tag can be used to specify an XML DTD,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_DTD                =
 
 # If the XML_PROGRAMLISTING tag is set to YES Doxygen will
 # dump the program listings (including syntax highlighting

--- a/cmake/Templates/Doxyfile
+++ b/cmake/Templates/Doxyfile
@@ -1640,7 +1640,7 @@ OUTPUT_DIRECTORY       = @PROJECT_BINARY_DIR@/@doxy_dir@
 # You can optionally specify a file name after the option, if omitted
 # DoxygenLayout.xml will be used as the name of the layout file.
 
-LAYOUT_FILE            = @OPM_MACROS_ROOT@/cmake/Templates/DoxygenLayout.xml
+LAYOUT_FILE            = @PROJECT_BINARY_DIR@/@doxy_dir@/DoxygenLayout.xml
 
 # The HTML_EXTRA_STYLESHEET tag can be used to specify an additional
 # user-defined cascading style sheet that is included after the standard


### PR DESCRIPTION
newer versions of doxgen complain about a few deprecated statements in the config file and also downstream modules should be able to specify their own layout file. this PR fixes these issues.