### PR TITLE
Refine static targets

### DIFF
--- a/cmake/Modules/OpmFiles.cmake
+++ b/cmake/Modules/OpmFiles.cmake
@@ -33,6 +33,7 @@ macro (opm_sources opm)
   # - TEST_DATA_FILES
   # - PUBLIC_HEADER_FILES
   # - PROGRAM_SOURCE_FILES
+  # - ADDITIONAL_SOURCE_FILES
 
   # rename from "friendly" names to ones that fit the "almost-structural"
   # scheme used in the .cmake modules, converting them to absolute file
@@ -61,6 +62,9 @@ macro (opm_sources opm)
   endforeach (_file)
   foreach (_file IN LISTS EXAMPLE_SOURCE_FILES)
 	list (APPEND examples_SOURCES ${PROJECT_SOURCE_DIR}/${_file})
+  endforeach (_file)
+  foreach (_file IN LISTS ADDITIONAL_SOURCE_FILES)
+	list (APPEND additionals_SOURCES ${PROJECT_SOURCE_DIR}/${_file})
   endforeach (_file)
   foreach (_file IN LISTS PROGRAM_SOURCE_FILES)
 	list (APPEND examples_SOURCES_DIST ${PROJECT_SOURCE_DIR}/${_file})

--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -223,6 +223,8 @@ if (BUILD_EXAMPLES)
 	opm_compile_satellites (${project} examples "" "")
 endif (BUILD_EXAMPLES)
 
+opm_compile_satellites (${project} additionals EXCLUDE_FROM_ALL "")
+
 # attic are programs which are not quite abandoned yet; however, they
 # are not actively maintained, so they should not be a part of the
 # default compile


### PR DESCRIPTION
- add support for ADDITIONAL programs which are not built by default, yet not abandoned (i.e. attic doesn't fit)
- refine OpmStaticTargets/opm_from_git
   - pass on toolchain file
    - don't build examples in static directories
    - allow non-install mode and custom targets
    - use origin/master to make sure static source trees are built from the top should user re-execute the build in an existing build tree.