### PR TITLE
Addes a module for finding ParMETIS or the ParMETIS interface of Scotch

### DIFF
--- a/cmake/Modules/FindParMETIS.cmake
+++ b/cmake/Modules/FindParMETIS.cmake
@@ -1,0 +1,97 @@
+# Module that checks whether ParMETIS or the ParMETIS interface of PT-Scotch
+# is available.
+#
+# Accepts the following variables:
+#
+# PARMETIS_ROOT:   Prefix where ParMETIS is installed.
+# PARMETIS_SUFFIX: Scotch might be compiled using different
+#                  integer sizes (int32, int32, long). When
+#                  this is is set the headers and libaries
+#                  are search under the suffix
+#                  include/parmetis-${PARMETIS_SUFFIX}, and
+#                  lib/parmetis-${PARMETIS_SUFFIX}, respectively.
+# Sets the following variables:
+# PARMETIS_INCLUDE_DIRS: All include directories needed to compile ParMETIS programs.
+# PARMETIS_LIBRARIES:    Alle libraries needed to link ParMETIS programs.
+# PARMETIS_FOUND:        True if ParMETIS was found.
+#
+# Provides the following macros:
+#
+# find_package(ParMETIS)
+
+find_package(MPI)
+macro(_search_parmetis_lib libvar libname doc)
+  find_library(${libvar} ${libname}
+    PATHS${PARMETIS_ROOT} PATH_SUFFIXES ${PATH_SUFFIXES}
+    NO_DEFAULT_PATH
+    DOC "${doc}")
+  find_library(${libvar} ${libname})
+endmacro(_search_parmetis_lib)
+
+if(PARMETIS_SUFFIX)
+  set(PATH_SUFFIXES "-${PARMETIS_SUFFIX}")
+else(PARMETIS_SUFFIX)
+  set(PATH_SUFFIXES "")
+endif(PARMETIS_SUFFIX)
+
+include(CMakePushCheckState)
+cmake_push_check_state() # Save variables
+
+message("PARMETIS_ROOT=${PARMETIS_ROOT} PATH_SUFFIXES=${PATH_SUFFIXES}")
+find_path(PARMETIS_INCLUDE_DIR parmetis.h
+  PATHS ${PARMETIS_ROOT}
+  PATH_SUFFIXES parmetis${PATH_SUFFIXES}
+  NO_DEFAULT_PATH
+  DOC "Include directory of ParMETIS")
+find_path(PARMETIS_INCLUDE_DIR parmetis.h
+  PATH_SUFFIXES parmetis${PATH_SUFFIXES})
+
+
+find_path(METIS_INCLUDE_DIR metis.h
+  PATHS ${PARMETIS_ROOT}
+  PATH_SUFFIXES metis${PATH_SUFFIXES}
+  NO_DEFAULT_PATH
+  DOC "Include directory of ParMETIS")
+find_path(METIS_INCLUDE_DIR metis.h
+  PATH_SUFFIXES metis${PATH_SUFFIXES})
+
+
+set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${MPI_C_INCLUDE_PATH} ${PARMETIS_INCLUDE_DIR} ${METIS_INCLUDE_DIR} )
+set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${MPI_C_COMPILE_FLAGS}")
+
+message("CMAKE_REQUIRED_INCLUDES=${CMAKE_REQUIRED_INCLUDES}")
+check_include_file(metis.h METIS_FOUND)
+check_include_file(parmetis.h PARMETIS_FOUND)
+_search_parmetis_lib(METIS_LIBRARY metis "The METIS library.")
+_search_parmetis_lib(PARMETIS_LIBRARY parmetis "The main ParMETIS library.")
+
+# behave like a CMake module is supposed to behave
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  "ParMETIS"
+  DEFAULT_MSG
+  PARMETIS_INCLUDE_DIR
+  PARMETIS_LIBRARY
+  METIS_LIBRARY
+  PARMETIS_FOUND
+  METIS_FOUND
+)
+#restore old values
+cmake_pop_check_state()
+
+if(PARMETIS_FOUND)
+  set(PARMETIS_INCLUDE_DIRS ${PARMETIS_INCLUDE_DIR})  
+  set(PARMETIS_LIBRARIES ${PARMETIS_LIBRARY} ${METIS_LIBRARY} ${MPI_C_LIBRARIES}
+    CACHE FILEPATH "All libraries needed to link programs using ParMETIS")
+  set(PARMETIS_LINK_FLAGS "${DUNE_C_LINK_FLAGS}"
+    CACHE STRING "ParMETIS link flags")
+  set(HAVE_PARMETIS 1)
+  # log result
+  file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
+    "Determining location of ParMETIS succeded:\n"
+    "Include directory: ${PARMETIS_INCLUDE_DIRS}\n"
+    "Library directory: ${PARMETIS_LIBRARIES}\n\n")
+
+endif(PARMETIS_FOUND)
+
+mark_as_advanced(PARMETIS_INCLUDE_DIRS PARMETIS_LIBRARIES HAVE_PARMETIS HAVE_METIS)

--- a/cmake/Modules/Finddune-istl.cmake
+++ b/cmake/Modules/Finddune-istl.cmake
@@ -17,6 +17,7 @@ find_opm_package (
 
   # required dependencies
   "dune-common REQUIRED;
+  ParMETIS;
   SuperLU;
   SuiteSparse COMPONENTS umfpack
   "


### PR DESCRIPTION
The AMG within dune-istl issues a warning if ParMETIS is not available.
The reason is that it uses ParMETIS or the ParMETIS bindings of PT-Scotch
to redistribute the load on the coarse levels. Even with an installed and
found PT-Scotch we need to adapt the include path and the libraries linked
to make it work.

Therefore this commit adds a module for searching for ParMETIS and activates
it whenever dune-istl is a dependency. With this the warning about missing
ParMETIS for flow_cp vanishes.