### PR TITLE
opm-material: add HAVE_TYPE_TRAITS to config.h

### DIFF
--- a/cmake/Modules/opm-material-prereqs.cmake
+++ b/cmake/Modules/opm-material-prereqs.cmake
@@ -4,6 +4,7 @@
 # defines that must be present in config.h for our headers
 set (opm-material_CONFIG_VAR
 	HAVE_MPI
+	HAVE_TYPE_TRAITS
 	HAVE_VALGRIND
 	HAVE_FINAL
 	)


### PR DESCRIPTION
dune has a compatibility layer for std::conditional and some versions
of it emit a deprecation warning if the HAVE_TYPE_TRAITS macro is
undefined:

http://opm-project.org/CDash/viewBuildError.php?type=1&buildid=41175